### PR TITLE
Mcb 19 data seed base

### DIFF
--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -7,3 +7,8 @@ spring.datasource.url=jdbc:mariadb://localhost:3306/{db_name}
 spring.datasource.username={user_name}
 spring.datasource.password={password}
 spring.jpa.hibernate.ddl-auto=update
+
+#seed
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
+spring.sql.init.encoding=UTF-8


### PR DESCRIPTION
## 작업 내용
- 데이터 시딩용 resources/data.sql 파일 생성
- application.properties.example 변수 추가
## 문제점
- data.sql을 이용해 시딩 작업을 하면 한 파일로 모든 테이블을 시딩해야 함
- spring.sql.init.mode=always 설정으로 인해 첫 실행 후 data.sql을 삭제하거나 해당 설정을 삭제해야 함
- raw sql을 작성해야 하므로 모든 값을 일일이 사람 손으로 적어야 함
- 위 문제점이 조금이라도 개선되는 좋은 시딩 방법이 있다면 그 방법으로 전환할 수 있음
## 리뷰 사항
- 정상 작동 여부
- 설정 이상 여부